### PR TITLE
Remove outputInline attribute

### DIFF
--- a/elementBoilerplate/settings.json
+++ b/elementBoilerplate/settings.json
@@ -42,7 +42,6 @@
     "value": [
       "output",
       "color",
-      "outputInline",
       "metaCustomId",
       "customClass"
     ],


### PR DESCRIPTION
There is no "outputInline" attribute for this element, so I guess there is also no need to have it in the editFormTab